### PR TITLE
docs: adiciona requisitos e restrições

### DIFF
--- a/docs/contexto.md
+++ b/docs/contexto.md
@@ -68,7 +68,7 @@ As tabelas que se seguem apresentam os requisitos funcionais e não funcionais q
 | RNF-001 | A comunicação entre as aplicações (web e mobile) e o servidor deve ser padronizada por meio de uma API REST.                                                | ALTA       |
 | RNF-002 | O sistema deve possuir tempo de resposta até 3 segundos para pesquisas e ações na agenda.                                                                   | MÉDIA      |
 | RNF-003 | A interface web deve ser responsiva para se adaptar e funcionar corretamente em diferentes tamanhos de tela.                                                | ALTA       |
-| RNF-004 | O aplicativo móvel deve ser compatível para rodar na plataforma Android e iOS.                                                                              | ALTA       |
+| RNF-004 | O aplicativo móvel deve ser compatível com as plataformas Android e iOS.                                                                                    | ALTA       |
 | RNF-005 | O sistema deve utilizar tokens JWT para garantir a autenticação e autorização segura em todas as requisições entre as aplicações e a API.                   | ALTA       |
 | RNF-006 | O sistema deve ser compatível com as versões mais recentes dos principais navegadores do mercado (Google Chrome, Mozilla Firefox, Safari e Microsoft Edge). | ALTA       |
 


### PR DESCRIPTION
Atualiza a documentação de contexto do projeto para substituir o conteúdo de template por uma lista concreta de requisitos funcionais/não funcionais e restrições do sistema de agendamento.

**Changes:**
- Expande e reescreve a tabela de Requisitos Funcionais (RF-001 a RF-005) voltada a agendamento/gestão de consultas.
- Expande e reescreve a tabela de Requisitos Não Funcionais (RNF-001 a RNF-006), incluindo API REST, performance, responsividade e JWT.
- Reescreve e amplia a seção de Restrições (01 a 06), alinhando com limites de escopo do produto.
